### PR TITLE
isPortOpen function added

### DIFF
--- a/index.js
+++ b/index.js
@@ -72,6 +72,10 @@ Input.prototype.close = function () {
   this._input.closePort();
 };
 
+Input.prototype.isPortOpen = function () {
+  return this._input.isPortOpen();
+};
+
 Input.prototype.parseMtc = function (data) {
   var byteNumber = data.type
   var value = data.value
@@ -206,6 +210,10 @@ var Output = function (name, virtual) {
 
 Output.prototype.close = function () {
   this._output.closePort();
+};
+
+Output.prototype.isPortOpen = function () {
+  return this._output.isPortOpen();
 };
 
 Output.prototype.send = function (type, args) {


### PR DESCRIPTION
As node-midi doesn't expose the RtMidi setErrorCallback function, there is no way to check if an error occurred when opening a MIDI port, except by calling the isPortOpen function. 