### PR TITLE
fixed MTC crash (`assignment to constant variable`)

### DIFF
--- a/index.js
+++ b/index.js
@@ -107,8 +107,8 @@ class Input extends EventEmitter {
 
   parseMtc(data) {
     const byteNumber = data.type;
-    const value = data.value;
     const smpte = [];
+    let value = data.value;
     let smpteMessageCounter = 0;
     let smpteType;
 


### PR DESCRIPTION
Hi,
before this change, the library would crash with the error `TypeError: Assignment to constant variable` in line 121.
Unfortunately, I don't have a program which sends Midi Timecodes, so I haven't testet this. But I believe that this should fix the problem.