### PR TITLE
Fix isPortOpen()

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -72,6 +72,7 @@ export declare class Input extends EventEmitter {
   on(evt: "reset", handler: () => void): this;
   on(evt: "sysex", handler: (param: Sysex) => void): this;
   close(): void;
+  isPortOpen(): boolean;
 }
 
 export declare class Output {
@@ -94,6 +95,7 @@ export declare class Output {
   send(evt: "reset"): void;
   send(evt: "sysex", param: Array<number>): void;
   close(): void;
+  isPortOpen(): boolean;
 }
 
 export declare function getInputs(): string[];

--- a/index.js
+++ b/index.js
@@ -102,7 +102,7 @@ class Input extends EventEmitter {
   }
 
   isPortOpen() {
-    this._input.isPortOpen();
+    return this._input.isPortOpen();
   }
 
   parseMtc(data) {
@@ -219,7 +219,7 @@ class Output {
   }
 
   isPortOpen() {
-    this._output.isPortOpen();
+    return this._output.isPortOpen();
   }
 
   send(type, args) {


### PR DESCRIPTION
The `isPortOpen()` function seemed to be broken(?). I would like to use it - this makes it usable again...